### PR TITLE
Lock freecam controls if chat is focused

### DIFF
--- a/Cammy.cs
+++ b/Cammy.cs
@@ -13,6 +13,7 @@ namespace Cammy
         public string Name => "Cammy";
         public static Cammy Plugin { get; private set; }
         public static Configuration Config { get; private set; }
+        public static Input? Input { get; set; }
 
         private readonly bool pluginReady = false;
 
@@ -35,6 +36,7 @@ namespace Cammy
 
                 Game.Initialize();
                 IPC.Initialize();
+                Input = new Input();
 
                 pluginReady = true;
             }

--- a/Cammy.csproj
+++ b/Cammy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyVersion>2.0.3.1</AssemblyVersion>
+    <AssemblyVersion>2.0.3.2</AssemblyVersion>
     <TargetFramework>net5.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;AnyCPU</Platforms>

--- a/FreeCam.cs
+++ b/FreeCam.cs
@@ -117,6 +117,8 @@ namespace Cammy
 
             if (!Enabled) return;
 
+            if (Input.Disabled || Cammy.Input == null) return;
+
             if (Game.IsInputIDPressed(366) || Game.IsInputIDReleased(433)) // Cycle through Enemies (Nearest to Farthest) / Controller Select HUD
             {
                 locked ^= true;

--- a/Input.cs
+++ b/Input.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Data;
+using System.Runtime.InteropServices;
+using Dalamud.Game.ClientState.Keys;
+using Dalamud.Logging;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using ImGuiNET;
+
+namespace Cammy {
+    // Most of this is stolen from QoLBar
+    public unsafe class Input
+    {
+        [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)] private static extern IntPtr GetForegroundWindow();
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)] private static extern int GetWindowThreadProcessId(IntPtr handle, out int processId);
+        public static bool IsGameFocused
+        {
+            get
+            {
+                var activatedHandle = GetForegroundWindow();
+                if (activatedHandle == IntPtr.Zero)
+                    return false;
+
+                var procId = Environment.ProcessId;
+                _ = GetWindowThreadProcessId(activatedHandle, out var activeProcId);
+
+                return activeProcId == procId;
+            }
+        }
+    
+        private static IntPtr isTextInputActivePtr = IntPtr.Zero;
+        private static bool IsGameTextInputActive => isTextInputActivePtr != IntPtr.Zero && *(bool*)isTextInputActivePtr;
+    
+        public static bool Disabled => IsGameTextInputActive || !IsGameFocused || ImGui.GetIO().WantCaptureKeyboard;
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetKeyboardState(byte[] lpKeyState);
+        private static readonly byte[] keyboardState = new byte[256];
+
+        public Input()
+        {
+            try { isTextInputActivePtr = *(IntPtr*)((IntPtr)AtkStage.GetSingleton() + 0x28) + 0x188E; } // Located in AtkInputManager
+            catch { PluginLog.LogError("Failed loading textActiveBoolPtr"); }
+        }
+
+        public void Update()
+        {
+            GetKeyboardState(keyboardState);
+        }
+
+        public bool IsDown(VirtualKey key) => (keyboardState[(int)key] & 0x80) != 0;
+    }
+}


### PR DESCRIPTION
I just grabbed code from Wotsit. Realised later it's kinda unnecessary since you can lock the camera and then the input to reset the camera won't trigger, but I guess this is quality of life?